### PR TITLE
Fix for htmlspecialchars() expects parameter 1 to be string, array given in /Data/Form/Element/AbstractElement.php 

### DIFF
--- a/lib/internal/Magento/Framework/Data/Form/Element/AbstractElement.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/AbstractElement.php
@@ -54,8 +54,7 @@ abstract class AbstractElement extends AbstractForm
     /**
      * @var Escaper
      */
-    protected $
-        r;
+    protected $;
 
     /**
      * Lock html attribute

--- a/lib/internal/Magento/Framework/Data/Form/Element/AbstractElement.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/AbstractElement.php
@@ -54,7 +54,8 @@ abstract class AbstractElement extends AbstractForm
     /**
      * @var Escaper
      */
-    protected $_escaper;
+    protected $
+        r;
 
     /**
      * Lock html attribute
@@ -284,7 +285,12 @@ abstract class AbstractElement extends AbstractForm
      */
     protected function _escape($string)
     {
-        return htmlspecialchars($string, ENT_COMPAT);
+        if( is_array( $string ) ){
+           return htmlspecialchars( implode(" ",$string), ENT_COMPAT );	
+        }
+        else{
+           return htmlspecialchars($string, ENT_COMPAT);
+        }
     }
 
     /**

--- a/lib/internal/Magento/Framework/Data/Form/Element/AbstractElement.php
+++ b/lib/internal/Magento/Framework/Data/Form/Element/AbstractElement.php
@@ -54,7 +54,7 @@ abstract class AbstractElement extends AbstractForm
     /**
      * @var Escaper
      */
-    protected $;
+    protected $_escaper;
 
     /**
      * Lock html attribute


### PR DESCRIPTION
### Description
Fix for this error:

> Warning: htmlspecialchars() expects parameter 1 to be string, array given in
> /vendor/magento/framework/Data/Form/Element/AbstractElement.php on line 286

Apparently, some form submissions when editing data in the admin area are passing an array element instead of a string to functions like getEscapedValue() which then call the _escape() function.

Not sure if this is the best fix for this, need someone more senior with Magento to evaluate.  But this fixes the issue I had with this.


### Fixed Issues
This error reported in https://github.com/magento/magento2/issues/7171



### Manual testing scenarios
For me this occurred in a third party extension - Mage Solution Front End Builder 2.  After I successfully saved a MegaMenu Item, then opening the homepage that should now display the megamenu was giving me this error and causing the page to not render.  After this code change the problem was resolved.

I don't know if there are any automated tests that need to be executed as I am not familiar with that in Magento dev yet.  This is our first Magento project.
